### PR TITLE
filebeat/input/httpjson: drain and close response.Body

### DIFF
--- a/x-pack/filebeat/input/httpjson/request.go
+++ b/x-pack/filebeat/input/httpjson/request.go
@@ -38,6 +38,15 @@ func (c *httpClient) do(stdCtx context.Context, trCtx *transformContext, req *ht
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute http client.Do: %w", err)
 	}
+	defer resp.Body.Close()
+
+	// Read the whole resp.Body so we can release the conneciton.
+	// This implementaion is inspired by httputil.DumpResponse
+	resp.Body, err = drainBody(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
 	if resp.StatusCode > 399 {
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
@@ -362,4 +371,28 @@ func (r *requester) processAndPublishEvents(stdCtx context.Context, trCtx *trans
 		n++
 	}
 	return n, nil
+}
+
+// drainBody reads all of b to memory and then returns a equivalent
+// ReadCloser yielding the same bytes.
+//
+// It returns an error if the initial slurp of all bytes fails. It does not attempt
+// to make the returned ReadCloser have identical error-matching behavior.
+//
+// This function is a modified version of drainBody from the http/httputil package.
+func drainBody(b io.ReadCloser) (r1 io.ReadCloser, err error) {
+	if b == nil || b == http.NoBody {
+		// No copying needed. Preserve the magic sentinel meaning of NoBody.
+		return http.NoBody, nil
+	}
+
+	var buf bytes.Buffer
+	if _, err = buf.ReadFrom(b); err != nil {
+		return b, err
+	}
+	if err = b.Close(); err != nil {
+		return b, err
+	}
+
+	return io.NopCloser(&buf), nil
 }


### PR DESCRIPTION
httpClient.do now reads the whole response.Body into memory and
replaces it with the in-memory copy. This brings some advantages:
 * We can easily ensure the response.Body is always closed
 * We read the response as quick as possible, releasing the connection
   to be reused and avoiding possible timeouts or other errors caused
   by keeping the connection open and blocked.

@kush-elastic this is a possible solution for closing the response.Body we discussed last week. I'm looking into getting this merged directly into `main` so you don't have to worry about it in your PR.